### PR TITLE
Revert "Bump logging-interceptor from 3.14.9 to 4.9.1"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,5 +64,5 @@ dependencies {
 
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
-    implementation "com.squareup.okhttp3:logging-interceptor:4.9.1"
+    implementation "com.squareup.okhttp3:logging-interceptor:3.14.9"
 }


### PR DESCRIPTION
Reverts KunMinX/Jetpack-MVVM-Best-Practice#63