### PR TITLE
Add fixed JDK version and OpenJDK distro to support it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: set up JDK 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Make gradlew executable
         run: chmod +x ./gradlew

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: set up JDK 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'temurin'
+          distribution: 'zulu'
           java-version: ${{ matrix.java }}
       - name: Make gradlew executable
         run: chmod +x ./gradlew

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,17 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, macOS-latest, windows-2016]
+        java: [11, 11.0.3, 17, 17.0.0+35] 
     steps:
       - uses: actions/checkout@v1
       - name: set up JDK 11
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
-          java-version: 11
+          java-version: ${{ matrix.java }}
       - name: Make gradlew executable
         run: chmod +x ./gradlew
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, macOS-latest, windows-2016]
-        java: [11, 11.0.3, 17, 17.0.0+35] 
+        java: [11, 11.0.3] 
     steps:
       - uses: actions/checkout@v1
       - name: set up JDK 11


### PR DESCRIPTION
Having a fixed version (e.g., 11.0.3) in addition to whatever is the latest version (e.g., 11) can be useful for regression testing, i.e., when your CI/CD pipeline results in green for 11.0.3 and red for 11, it means that there's a problem related specifically to the latest version and not to the fixed version. Adopt needs to be replaced by either Temurin or Zulu, while Zulu has all the historical major and minor versions, hence the pull request suggests changing to Zulu as well.